### PR TITLE
Reorder setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 
 .byebug_history
 /coverage/
+
 # Ignore application configuration
 /config/application.yml

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Follow the instructions at [Unsplash API Documentation](https://unsplash.com/doc
 $ git clone git@github.com:alex-latham/sweater_weather.git
 $ cd sweater_weather
 $ bundle install
-$ bundle exec rake db:setup
 $ bundle exec figaro install
 $ echo GOOGLE_API_KEY: <Google_API_Key> >> config/application.yml
 $ echo OPEN_WEATHER_API_KEY: <OpenWeather_API_Key> >> config/application.yml
 $ echo UNSPLASH_CLIENT_ID: <Unsplash_Client_ID> >> config/application.yml
+$ bundle exec rake db:setup
 $ rails server
 ```
 


### PR DESCRIPTION
Previously, setup instructions asked for the user to run `bundle exec rake db:setup` before setting up Figaro and inserting some required API keys. This results in the following error:

```shell
rake aborted!
Figaro::MissingKeys: Missing required configuration keys: ["GOOGLE_API_KEY", "OPEN_WEATHER_API_KEY"]
```

This is due to Figaro's configuration file (at `/config/initializers/figaro.rb`) is loaded upon Postgres setup. This file specifies a GOOGLE_API_KEY and an OPEN_WEATHER_API_KEY be provided (at `/config/applicaton.yml`). This PR moves the db:setup step to after the Figaro configuration steps.