### PR TITLE
Add rake task for setup & update README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development do
   gem 'listen'
   gem 'spring'
   gem 'spring-watcher-listen'
+  gem 'rake'
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,7 @@ DEPENDENCIES
   pry
   puma
   rails (~> 5.1.7)
+  rake
   rspec-rails
   rubocop-rails
   shoulda-matchers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sweater Weather
+# Sweater Weather [![Build Status](https://travis-ci.com/alex-latham/sweater_weather.svg?branch=master)](https://travis-ci.com/alex-latham/sweater_weather)
 
 ## Versions
 * Ruby 2.5.3

--- a/README.md
+++ b/README.md
@@ -26,11 +26,7 @@ Follow the instructions at [Unsplash API Documentation](https://unsplash.com/doc
 $ git clone git@github.com:alex-latham/sweater_weather.git
 $ cd sweater_weather
 $ bundle install
-$ bundle exec figaro install
-$ echo GOOGLE_API_KEY: <Google_API_Key> >> config/application.yml
-$ echo OPEN_WEATHER_API_KEY: <OpenWeather_API_Key> >> config/application.yml
-$ echo UNSPLASH_CLIENT_ID: <Unsplash_Client_ID> >> config/application.yml
-$ bundle exec rake db:setup
+$ rails sw:setup
 $ rails server
 ```
 

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -3,4 +3,5 @@
   .rbenv-vars
   tmp/restart.txt
   tmp/caching-dev.txt
+  config/application.yml
 ].each { |path| Spring.watch(path) }

--- a/lib/tasks/sw.rake
+++ b/lib/tasks/sw.rake
@@ -1,0 +1,16 @@
+namespace :sw do
+  desc "This task contains sweater_weather actions"
+  task :setup do
+    sh "bundle exec figaro install"
+    STDOUT.puts "Please enter your Google API key:"
+    GOOGLE_API_KEY = STDIN.gets.chomp
+    sh "echo GOOGLE_API_KEY: #{GOOGLE_API_KEY} >> config/application.yml"
+    STDOUT.puts  "Please enter your OpenWeather API key:"
+    OPEN_WEATHER_API_KEY = STDIN.gets.chomp
+    sh "echo OPEN_WEATHER_API_KEY: #{OPEN_WEATHER_API_KEY} >> config/application.yml"
+    STDOUT.puts  "Please enter your Unsplash client ID:"
+    UNSPLASH_CLIENT_ID = STDIN.gets.chomp
+    sh "echo UNSPLASH_CLIENT_ID: #{UNSPLASH_CLIENT_ID} >> config/application.yml"
+    sh "rake db:setup"
+  end
+end


### PR DESCRIPTION
This PR adds a new feature for simplifying setup. Instead of entering three similar commands for updating environmental variables (API keys, client ID), users can now use `rails sw:setup` to create an application.yml folder, .gitignore it, and enter each key/ID through a CLI. It will also run db:setup to create the necessary local development and test databases.

Other notes:
* README reflects updated setup instructions (tested locally)
* Per [Figaro's readme](https://github.com/laserlemon/figaro) instructions, this PR adds Figaro to Spring's watchlist at config/spring.rb
* Adds build status to README